### PR TITLE
clubs cannot book past competition, added test for it

### DIFF
--- a/server.py
+++ b/server.py
@@ -57,12 +57,15 @@ def purchasePlaces():
     competition = [c for c in competitions if c["name"] == request.form["competition"]][
         0
     ]
+    date_competition = datetime.strptime(competition["date"], "%Y-%m-%d %H:%M:%S")
     club = [c for c in clubs if c["name"] == request.form["club"]][0]
     placesRequired = int(request.form["places"])
     if placesRequired > int(club["points"]):
         flash("Your club does not have enough points to participate.")
     elif placesRequired > MAX_PLACES:
         flash("You cannot book more than 12 places.")
+    elif datetime.now() > date_competition:
+        flash("Purchase not allowed - Outdated competition.")
     else:
         competition["numberOfPlaces"] = (
             int(competition["numberOfPlaces"]) - placesRequired

--- a/tests/unitary_tests/test_purchase_places.py
+++ b/tests/unitary_tests/test_purchase_places.py
@@ -11,7 +11,7 @@ def test_clubs_purchase_places_working(client, mock_clubs_and_competitions):
     """
     response = client.post(
         "/purchasePlaces",
-        data={"club": "Iron Temple", "competition": "Fall Classic", "places": "4"},
+        data={"club": "Iron Temple", "competition": "Spring Boxing", "places": "4"},
     )
     data = response.data.decode()
     assert response.status_code == 200
@@ -42,3 +42,13 @@ def test_clubs_purchase_more_than_twelve_places(client, mock_clubs_and_competiti
     data = response.data.decode()
     assert response.status_code == 200
     assert "You cannot book more than 12 places." in data
+
+
+def tests_clubs_purchase_outdated_competition(client, mock_clubs_and_competitions):
+    response = client.post(
+        "/purchasePlaces",
+        data={"club": "Wing chun", "competition": "Fall Classic", "places": "1"},
+    )
+    data = response.data.decode()
+    assert response.status_code == 200
+    assert "Purchase not allowed - Outdated competition." in data


### PR DESCRIPTION
Clubs cannot purchase past competitions.
Using the datetime module in the 'purchasePlaces' endpoint.
Added test for it and fixed the first test which was using an outdated tournament before this issue was being considered.